### PR TITLE
Correcting a warning pointed by SonarQube (bug 4 - issue #18)

### DIFF
--- a/alerter/src/main/java/org/dromara/hertzbeat/alert/calculate/CalculateAlarm.java
+++ b/alerter/src/main/java/org/dromara/hertzbeat/alert/calculate/CalculateAlarm.java
@@ -116,8 +116,8 @@ public class CalculateAlarm {
                     if (metricsData != null) {
                         calculate(metricsData);
                     }
-                } catch (InterruptedException ignored) {
-
+                } catch (InterruptedException ignored) { // There is a change here: filling in the code block
+                    Thread.currentThread().interrupt();
                 } catch (Exception e) {
                     log.error("calculate alarm error: {}.", e.getMessage(), e);
                 }


### PR DESCRIPTION
## Goal
- Correcting a warning pointed by SonarQube

## Problem
- There is an empty code block from the _alerter_ module in the calculate - class **CalculateAlarm**
- This empty code block refered to an **_InterruptionException ignored_** in a _catch block_
- It has a medium impact in the reliability

## What's changed?
- The empty code block was filled with a correct and clean code according to exception

See the images below about the problem 👇🏻 
![Captura de tela de 2024-02-02 15-40-08](https://github.com/karolalencar/ES2_2023-2_Hertzbeat/assets/110498717/fc9baafe-08b6-4ee1-a2ed-461cb7632b0d)
![Captura de tela de 2024-02-02 15-41-04](https://github.com/karolalencar/ES2_2023-2_Hertzbeat/assets/110498717/86b280ca-2511-4583-88fd-5e09a41558f2)
