### PR TITLE
Correcting a warning pointed by SonarQube (bug 6 - issue #20)

### DIFF
--- a/collector/src/main/java/org/dromara/hertzbeat/collector/collect/ftp/FtpCollectImpl.java
+++ b/collector/src/main/java/org/dromara/hertzbeat/collector/collect/ftp/FtpCollectImpl.java
@@ -82,10 +82,12 @@ public class FtpCollectImpl extends AbstractCollect {
             log.info("[FTPClient] error: {}", CommonUtil.getMessageFromThrowable(e), e);
             throw new IllegalArgumentException(e.getMessage());
         }
-        return new HashMap<>(8) {{
-            put("isActive", Boolean.toString(isActive));
-            put("responseTime", responseTime);
-        }};
+        
+        Map source = new HashMap<>(8);
+        source.put("isActive", Boolean.toString(isActive));
+        source.put("responseTime", responseTime);
+        
+        return source;
     }
 
     /**


### PR DESCRIPTION
## Goal

- Correcting an issue pointed by SonarQube

## Problem

- The way the instance HashMap is initialized is Non-Compliant
- Double Brace Initialization (DBI) creates an anonymous class with a reference to the instance of the owning object, its use can lead to memory leaks if the anonymous inner class is returned and held by other objects. Even when there’s no leak, DBI is so obscure that it’s bound to confuse most maintainers

## What's changed?

- Changed the way the instance is initialized to the way suggested by SonarQube

See images below about the problem
![Sem título](https://github.com/karolalencar/ES2_2023-2_Hertzbeat/assets/57328336/f1e6597d-6bf1-4dcc-b8c0-92a6d0e1983d)
![Sem título-1](https://github.com/karolalencar/ES2_2023-2_Hertzbeat/assets/57328336/41a58bcf-eb72-40a4-9b22-7cb7a41283b3)


<!-- Describe Your PR Here -->

