### PR TITLE
Correcting a code smell pointed by SonarQube (bug 2 - issue #16)

### DIFF
--- a/manager/src/main/java/org/dromara/hertzbeat/manager/component/alerter/DispatcherAlarm.java
+++ b/manager/src/main/java/org/dromara/hertzbeat/manager/component/alerter/DispatcherAlarm.java
@@ -93,19 +93,19 @@ public class DispatcherAlarm implements InitializingBean {
         return false;
     }
 
-    private NoticeReceiver getOneReceiverById(Long id) {
-        return noticeConfigService.getOneReceiverById(id);
-    }
-
-    private NoticeTemplate getOneTemplateById(Long id) {
-        return noticeConfigService.getOneTemplateById(id);
-    }
-
-    private List<NoticeRule> matchNoticeRulesByAlert(Alert alert) {
-        return noticeConfigService.getReceiverFilterRule(alert);
-    }
-
     private class DispatchTask implements Runnable {
+
+        private NoticeReceiver getOneReceiverById(Long id) {
+            return noticeConfigService.getOneReceiverById(id);
+        }
+
+        private NoticeTemplate getOneTemplateById(Long id) {
+            return noticeConfigService.getOneTemplateById(id);
+        }
+
+        private List<NoticeRule> matchNoticeRulesByAlert(Alert alert) {
+            return noticeConfigService.getReceiverFilterRule(alert);
+        }
 
         @Override
         public void run() {


### PR DESCRIPTION
## Goal

- Correcting a code smell pointed by SonarQube

## Problem

- DispatcherAlarm class has three private methods that are only used inside a inner class
- "Private" methods called only by inner classes should be moved to those classes
- That issue has a minor impact in Maintainability

## What's changed?

- The private methods were moved from DispatcherAlarm to the DispatchTask inner class
